### PR TITLE
Fix React lazy load error for FloatingPlayer component

### DIFF
--- a/src/pages/AIGenerationStudio.tsx
+++ b/src/pages/AIGenerationStudio.tsx
@@ -30,7 +30,10 @@ const TaskQueuePanel = lazy(() => import("@/features/ai-generation/components/Ta
 const TrackResultsGrid = lazy(() => import("@/features/ai-generation/components/TrackResultsGrid"));
 const TrackDetailsDrawer = lazy(() => import("@/features/ai-generation/components/TrackDetailsDrawer"));
 const CommandPalette = lazy(() => import("@/features/ai-generation/components/CommandPalette"));
-const FloatingPlayer = lazy(() => import("@/features/ai-generation/components/FloatingPlayer"));
+const FloatingPlayer = lazy(() =>
+  import("@/features/ai-generation/components/FloatingPlayer")
+  .then(module => ({ default: module.FloatingPlayer }))
+);
 
 interface Track {
   id: string;


### PR DESCRIPTION
The `FloatingPlayer` component was being lazy-loaded in `AIGenerationStudio.tsx`, but it is a named export, not a default export. This caused a "Minified React error #306" because `React.lazy` expects a default export.

This commit fixes the issue by updating the `React.lazy` call to correctly handle the named export.