### PR TITLE
Fix: Resolve runtime errors in AIGenerationStudio

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,3 +16,16 @@ export function formatDuration(seconds?: number): string {
   
   return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 }
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
+    return (error as any).message;
+  }
+  return 'An unknown error occurred';
+}

--- a/src/pages/AIGenerationStudio.tsx
+++ b/src/pages/AIGenerationStudio.tsx
@@ -14,7 +14,7 @@ import { useTrackSync } from "@/hooks/useTrackSync";
 import { MobileHeader } from "@/components/mobile/MobileHeader";
 import { MobileBottomNav } from "@/components/mobile/MobileBottomNav";
 import { GenerationParams } from "@/features/ai-generation/types";
-import { cn } from "@/lib/utils";
+import { cn, getErrorMessage } from "@/lib/utils";
 import { useLocation } from "react-router-dom";
 import { useSidebar } from "@/components/ui/sidebar";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -104,13 +104,6 @@ export default function AIGenerationStudio() {
     console.log('📢 Received tracks-updated event, refreshing tracks...');
     fetchTracks();
   });
-
-  // Listen for play-track events from other components
-  useEventListener('play-track', (data) => {
-    if (data?.track) {
-      handlePlayTrack(data.track as Track);
-    }
-  }, [handlePlayTrack]);
 
   // Core State
   const [searchQuery, setSearchQuery] = useState("");
@@ -274,7 +267,7 @@ export default function AIGenerationStudio() {
         console.error('[AIGenerationStudio] Error fetching tracks:', error);
         toast({
           title: "Ошибка загрузки треков",
-          description: error.message,
+          description: getErrorMessage(error),
           variant: "destructive"
         });
         return;
@@ -326,7 +319,7 @@ export default function AIGenerationStudio() {
       console.error('[AIGenerationStudio] Unexpected error fetching tracks:', error);
       toast({
         title: "Ошибка загрузки",
-        description: "Произошла неожиданная ошибка при загрузке треков",
+        description: getErrorMessage(error),
         variant: "destructive"
       });
     }
@@ -349,7 +342,7 @@ export default function AIGenerationStudio() {
       console.error('❌ Sync error:', error);
       toast({
         title: 'Ошибка синхронизации',
-        description: `Не удалось обновить список треков: ${error instanceof Error ? error.message : 'Неизвестная ошибка'}`,
+        description: getErrorMessage(error),
         variant: 'destructive'
       });
     }
@@ -380,7 +373,7 @@ export default function AIGenerationStudio() {
       console.error('Generation error:', error);
       toast({
         title: t('generationError'),
-        description: error.message || t('generationErrorDesc'),
+        description: getErrorMessage(error),
         variant: "destructive"
       });
     }
@@ -409,6 +402,13 @@ export default function AIGenerationStudio() {
     // Close track details drawer when starting playback
     setIsTrackDetailsOpen(false);
   }, [currentPlayingTrack, isPlaying, toast]);
+
+  // Listen for play-track events from other components
+  useEventListener('play-track', (data) => {
+    if (data?.track) {
+      handlePlayTrack(data.track as Track);
+    }
+  }, [handlePlayTrack]);
   const handlePlayerPlayPause = (playing: boolean) => {
     setIsPlaying(playing);
   };


### PR DESCRIPTION
This commit addresses two runtime errors that were occurring in the AIGenerationStudio component:

1.  `ReferenceError: Cannot access 'handlePlayTrack' before initialization` This was caused by the `useEventListener` hook for the 'play-track' event being defined before the `handlePlayTrack` function it depends on. The hook has been moved to after the function's definition to resolve this.

2.  `TypeError: Cannot convert object to primitive value` This error was likely caused by passing a non-string value to the `toast` function's description. A new utility function, `getErrorMessage`, has been added to safely extract a string message from an unknown error type. This function is now used in all relevant `catch` blocks within the component to prevent this error.