### PR TITLE
Fix: Resolve multiple runtime errors in AIGenerationStudio

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,3 +16,16 @@ export function formatDuration(seconds?: number): string {
   
   return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 }
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
+    return (error as any).message;
+  }
+  return 'An unknown error occurred';
+}


### PR DESCRIPTION
This commit addresses several runtime errors in the AIGenerationStudio component:

1.  **`TypeError: Cannot convert object to primitive value`**: This was caused by an incorrect import of lazy-loaded components that use named exports. The `React.lazy` import syntax has been updated to correctly handle these named exports.

2.  **`ReferenceError: Cannot access 'handlePlayTrack' before initialization`**: This was caused by the `useEventListener` hook for the 'play-track' event being defined before the `handlePlayTrack` function it depends on. The hook has been moved to after the function's definition.

3.  **`ReferenceError: useCallback is not defined`**: This was introduced in a previous fix and is resolved by adding `useCallback` to the `react` import statement.

Additionally, to improve error handling robustness and prevent similar `TypeError` issues in the future, a `getErrorMessage` utility function has been added and implemented in the component's `catch` blocks.