### PR TITLE
fix(supabase): Allow cross-origin requests in update-processing-statu…

### DIFF
--- a/supabase/functions/update-processing-status/index.ts
+++ b/supabase/functions/update-processing-status/index.ts
@@ -20,7 +20,7 @@ Deno.serve(async (req: Request) => {
     return new Response(null, { 
       headers: {
         ...corsHeaders,
-        'Access-Control-Allow-Origin': 'https://zwbhlfhwymbmvioaikvs.supabase.co',
+        'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
       }
     });


### PR DESCRIPTION
…s function

The `update-processing-status` Supabase function had an incorrect CORS configuration for OPTIONS preflight requests, which was blocking calls from the web application.

This change modifies the `Access-Control-Allow-Origin` header from a hardcoded Supabase URL to a wildcard `'*'`, aligning it with the other response headers in the function and resolving the cross-origin request issue.