### PR TITLE
fix(telegram): Remove unsupported enableClosingConfirmation call

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
         // Initialize app
         tg.ready();
         tg.expand();
-        tg.enableClosingConfirmation();
         
         // Apply theme
         if (tg.colorScheme === 'dark') {


### PR DESCRIPTION
Removes the call to `tg.enableClosingConfirmation()` from the Telegram Web App initialization script in `index.html`.

This call was causing a console error indicating that the feature is not supported in version 6.0 of the Telegram Web App library. Removing the call resolves the error without affecting other functionality.

This commit also acknowledges that other errors were reported in the initial issue, but they were determined to be related to external service configurations (Supabase) or were untraceable in the codebase (aria-hidden issue) and are not addressed by this change.